### PR TITLE
Fix: windowsでnpm installできない問題

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "postinstall": "./node_modules/bower/bin/bower install",
+    "postinstall": "node ./node_modules/bower/bin/bower install",
     "pretest": "eslint .",
     "test": "echo \"No test specified\"",
     "start": "nodemon index.js"


### PR DESCRIPTION
windowsではbowerをnpm installで正しくインストールできなかったため、postinstallを編集しました。Linux環境では動作確認は行っていません。